### PR TITLE
Maximum rating for gravatars, not minimum

### DIFF
--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -7,9 +7,9 @@
  */
  
 // for the configuration manager
-$lang['namespace'] = 'namespace for local avatars';
-$lang['size']      = 'default size of avatar';
-$lang['rating']    = 'minimum rating for gravatars';
-$lang['default']   = 'type of default gravatars';
+$lang['namespace'] = 'Namespace for local avatars';
+$lang['size']      = 'Default size of avatar';
+$lang['rating']    = 'Maximum rating for gravatars';
+$lang['default']   = 'Type of default gravatars';
 
 //Setup VIM: ex: et ts=2 enc=utf-8 :


### PR DESCRIPTION
Documentation in "conf/default.php" tells that the "rating" parameter is the _maximum_ rating for gravatars, not the minimum.
The page at https://en.gravatar.com/site/implement/images/ tells the same:

> Using the r= or rating= parameters, you may specify one of the following ratings to request images **up to and including that rating**: ...

I have also changed the first letter of all descriptions to upper case, as it seems to be the default case in configuration labels.